### PR TITLE
feat: add token authentication endpoints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,11 @@ utoipa-swagger-ui = "7"
 utoipauto = "0.1.12"
 mockall = "0.13"
 once_cell = "1.8"
+rand = "0.8"
+sha2 = "0.10"
+base64 = "0.21"
+hex = "0.4"
+chrono = { version = "0.4", features = ["serde", "clock"] }
 
 [dev-dependencies]
 reqwest = { version = "0.12", features = ["json"] }

--- a/README.md
+++ b/README.md
@@ -177,13 +177,32 @@ The `utoipa-swagger-ui` crate downloads the Swagger UI assets at build time. Ens
 ### Token Authentication
 Two additional endpoints demonstrate a secure token flow:
 
-- `POST /api/v1/auth/token` – generates a cryptographically secure, short‑lived token.
+- `POST /api/v1/auth/token` – accepts either a username/password or a client_id/client_secret and returns a cryptographically secure, short‑lived token.
 - `GET /api/v1/protected` – returns protected data and requires the token in an `Authorization: Bearer <token>` header.
 
 To test using Swagger UI:
 1. Open `/api/v1/swagger-ui` in the browser.
-2. Execute the `POST /auth/token` endpoint and copy the returned token.
-3. Click the **Authorize** button in Swagger and enter `Bearer <token>` as the value.
+2. Execute the `POST /auth/token` endpoint providing credentials, for example:
+
+```json
+{
+  "grant_type": "user",
+  "username": "admin",
+  "password": "password"
+}
+```
+
+or
+
+```json
+{
+  "grant_type": "client",
+  "client_id": "client",
+  "client_secret": "secret"
+}
+```
+
+3. Copy the returned token and click the **Authorize** button in Swagger, entering `Bearer <token>` as the value.
 4. Call `GET /protected`; it will respond only when a valid token is supplied.
 
 ## Getting Started

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Rust-Base-Backend is a foundational backend project written in Rust, designed wi
 - Error handling conforming to RFC 7807
 - Asynchronous programming with Tokio
 - Swagger integration for API documentation using OpenAPI
+- Secure token-based authentication
 
 ## Architecture
 The project is structured to follow the principles of clean architecture, ensuring separation of concerns and maintainability. The main components include:
@@ -172,6 +173,18 @@ The project integrates Swagger for API documentation using OpenAPI. This allows 
 To enable Swagger documentation in the project, ensure that the necessary dependencies are included and configured to generate the OpenAPI specification, which can then be served and viewed using tools like Swagger UI.
 
 The `utoipa-swagger-ui` crate downloads the Swagger UI assets at build time. Ensure network access is available, or provide an alternate archive URL via the `SWAGGER_UI_DOWNLOAD_URL` environment variable before running `cargo build` or `cargo test`.
+
+### Token Authentication
+Two additional endpoints demonstrate a secure token flow:
+
+- `POST /api/v1/auth/token` – generates a cryptographically secure, short‑lived token.
+- `GET /api/v1/protected` – returns protected data and requires the token in an `Authorization: Bearer <token>` header.
+
+To test using Swagger UI:
+1. Open `/api/v1/swagger-ui` in the browser.
+2. Execute the `POST /auth/token` endpoint and copy the returned token.
+3. Click the **Authorize** button in Swagger and enter `Bearer <token>` as the value.
+4. Call `GET /protected`; it will respond only when a valid token is supplied.
 
 ## Getting Started
 

--- a/src/controllers/auth_controller.rs
+++ b/src/controllers/auth_controller.rs
@@ -1,10 +1,7 @@
 use std::sync::Arc;
-use warp::{http::StatusCode, reply::with_status};
 
 use crate::models::{
-    auth_request::AuthRequestDto,
-    error_response::ErrorResponse,
-    token_model::TokenResponseDto,
+    auth_request::AuthRequestDto, error_response::ErrorResponse, token_model::TokenResponseDto,
 };
 use crate::services::auth_service::AuthService;
 
@@ -31,21 +28,4 @@ pub async fn generate_token<S: AuthService + Send + Sync>(
         Ok(token) => Ok(warp::reply::json(&token)),
         Err(e) => Err(warp::reject::custom(e)),
     }
-}
-
-#[utoipa::path(
-    get,
-    path = "/api/v1/protected",
-    tag = "Protected",
-    security(("api_key" = [])),
-    responses(
-        (status = 200, body = String),
-        (status = 401, description = "Unauthorized", body = ErrorResponse)
-    )
-)]
-pub async fn protected_endpoint() -> Result<impl warp::Reply, warp::Rejection> {
-    Ok(with_status(
-        warp::reply::json(&serde_json::json!({"message": "Top secret"})),
-        StatusCode::OK,
-    ))
 }

--- a/src/controllers/auth_controller.rs
+++ b/src/controllers/auth_controller.rs
@@ -1,18 +1,26 @@
 use std::sync::Arc;
 use warp::{http::StatusCode, reply::with_status};
 
-use crate::models::auth_request::AuthRequestDto;
+use crate::models::{
+    auth_request::AuthRequestDto,
+    error_response::ErrorResponse,
+    token_model::TokenResponseDto,
+};
 use crate::services::auth_service::AuthService;
 
 #[utoipa::path(
     post,
     path = "/api/v1/auth/token",
     tag = "Authentication",
-    request_body = crate::models::auth_request::AuthRequestDto,
+    request_body(
+        content = AuthRequestDto,
+        description = "User/password or client credentials used to request a token",
+        content_type = "application/json"
+    ),
     responses(
-        (status = 200, body = crate::models::token_model::TokenResponseDto),
-        (status = 401, body = crate::models::error_response::ErrorResponse),
-        (status = 500, body = crate::models::error_response::ErrorResponse)
+        (status = 200, description = "Token generated", body = TokenResponseDto),
+        (status = 401, description = "Unauthorized", body = ErrorResponse),
+        (status = 500, description = "Internal server error", body = ErrorResponse)
     )
 )]
 pub async fn generate_token<S: AuthService + Send + Sync>(
@@ -32,7 +40,7 @@ pub async fn generate_token<S: AuthService + Send + Sync>(
     security(("api_key" = [])),
     responses(
         (status = 200, body = String),
-        (status = 401, description = "Unauthorized", body = crate::models::error_response::ErrorResponse)
+        (status = 401, description = "Unauthorized", body = ErrorResponse)
     )
 )]
 pub async fn protected_endpoint() -> Result<impl warp::Reply, warp::Rejection> {

--- a/src/controllers/auth_controller.rs
+++ b/src/controllers/auth_controller.rs
@@ -1,0 +1,37 @@
+use std::sync::Arc;
+use warp::{http::StatusCode, reply::with_status};
+
+use crate::services::auth_service::AuthService;
+
+#[utoipa::path(
+    post,
+    path = "/api/v1/auth/token",
+    tag = "Authentication",
+    responses(
+        (status = 200, body = crate::models::token_model::TokenResponseDto),
+        (status = 500, body = crate::models::error_response::ErrorResponse)
+    )
+)]
+pub async fn generate_token<S: AuthService + Send + Sync>(
+    service: Arc<S>,
+) -> Result<impl warp::Reply, warp::Rejection> {
+    let token = service.generate_token().await;
+    Ok(warp::reply::json(&token))
+}
+
+#[utoipa::path(
+    get,
+    path = "/api/v1/protected",
+    tag = "Protected",
+    security(("api_key" = [])),
+    responses(
+        (status = 200, body = String),
+        (status = 401, description = "Unauthorized", body = crate::models::error_response::ErrorResponse)
+    )
+)]
+pub async fn protected_endpoint() -> Result<impl warp::Reply, warp::Rejection> {
+    Ok(with_status(
+        warp::reply::json(&serde_json::json!({"message": "Top secret"})),
+        StatusCode::OK,
+    ))
+}

--- a/src/controllers/mod.rs
+++ b/src/controllers/mod.rs
@@ -1,18 +1,85 @@
+pub mod auth_controller;
 pub mod base_controller;
 
-use warp::Rejection;
+use std::convert::Infallible;
 use std::sync::Arc;
+use warp::{Filter, Rejection};
 
-use crate::repositories::base_Repository::InMemoryBaseRepository;
-use crate::services::base_service::BaseServiceImpl;
 use crate::config::Config;
+use crate::errors::ApiError;
+use crate::repositories::base_Repository::InMemoryBaseRepository;
+use crate::repositories::token_repository::InMemoryTokenRepository;
 use crate::router::Router;
+use crate::services::auth_service::{AuthService, AuthServiceImpl};
+use crate::services::base_service::{BaseService, BaseServiceImpl};
 
+pub fn routes(
+    config: Arc<Config>,
+) -> impl Filter<Extract = impl warp::Reply, Error = Rejection> + Clone {
+    let base_repository = InMemoryBaseRepository::new();
+    let base_service = BaseServiceImpl::new(base_repository);
+    let base_router = Router::new(base_service, Arc::clone(&config)).routes();
 
-pub fn base_routes(config: Arc<Config>) -> impl warp::Filter<Extract = impl warp::Reply, Error = Rejection> +Clone {
-  let repository = InMemoryBaseRepository::new();
-  let service = BaseServiceImpl::new(repository);
-  let router = Router::new(service, Arc::clone(&config));
+    let token_repository = InMemoryTokenRepository::new();
+    let auth_service = AuthServiceImpl::new(token_repository);
+    let auth_routes = build_auth_routes(auth_service, Arc::clone(&config));
 
-  router.routes()
+    base_router.or(auth_routes)
+}
+
+fn build_auth_routes<S: AuthService + Send + Sync + 'static>(
+    service: S,
+    config: Arc<Config>,
+) -> impl Filter<Extract = impl warp::Reply, Error = Rejection> + Clone {
+    let service = Arc::new(service);
+    let api_base = config.api_base.trim_matches('/').to_string();
+    let segments: Vec<String> = api_base.split('/').map(|s| s.to_string()).collect();
+
+    let mut api_path = warp::path(segments[0].clone()).boxed();
+    for seg in &segments[1..] {
+        api_path = api_path.and(warp::path(seg.clone())).boxed();
+    }
+
+    let auth_token = warp::post()
+        .and(api_path.clone())
+        .and(warp::path("auth"))
+        .and(warp::path("token"))
+        .and(warp::path::end())
+        .and(with_auth_service(Arc::clone(&service)))
+        .and_then(auth_controller::generate_token);
+
+    let protected = warp::get()
+        .and(api_path.clone())
+        .and(warp::path("protected"))
+        .and(warp::path::end())
+        .and(authorize(Arc::clone(&service)))
+        .and_then(auth_controller::protected_endpoint);
+
+    auth_token.or(protected)
+}
+
+fn with_auth_service<S: AuthService + Send + Sync + 'static>(
+    service: Arc<S>,
+) -> impl Filter<Extract = (Arc<S>,), Error = Infallible> + Clone {
+    warp::any().map(move || Arc::clone(&service))
+}
+
+fn authorize<S: AuthService + Send + Sync + 'static>(
+    service: Arc<S>,
+) -> impl Filter<Extract = (), Error = Rejection> + Clone {
+    warp::header::optional::<String>("authorization")
+        .and_then(move |header: Option<String>| {
+            let svc = Arc::clone(&service);
+            async move {
+                if let Some(h) = header {
+                    if let Some(token) = h.strip_prefix("Bearer ") {
+                        if svc.validate_token(token).await {
+                            return Ok(());
+                        }
+                    }
+                }
+                Err(warp::reject::custom(ApiError::Unauthorized))
+            }
+        })
+        .untuple_one()
 }

--- a/src/controllers/protected_controller.rs
+++ b/src/controllers/protected_controller.rs
@@ -1,0 +1,20 @@
+use warp::{http::StatusCode, reply::with_status};
+
+use crate::models::error_response::ErrorResponse;
+
+#[utoipa::path(
+    get,
+    path = "/api/v1/protected",
+    tag = "Protected",
+    security(("api_key" = [])),
+    responses(
+        (status = 200, body = String),
+        (status = 401, description = "Unauthorized", body = ErrorResponse)
+    )
+)]
+pub async fn protected_endpoint() -> Result<impl warp::Reply, warp::Rejection> {
+    Ok(with_status(
+        warp::reply::json(&serde_json::json!({"message": "Top secret"})),
+        StatusCode::OK,
+    ))
+}

--- a/src/errors/mod.rs
+++ b/src/errors/mod.rs
@@ -1,74 +1,140 @@
 pub mod error_codes;
 
+use crate::errors::error_codes::ErrorCodes;
+use crate::errors::error_codes::ERROR_CODES;
+use crate::models::error_response::ErrorResponse;
+use crate::models::error_response::ValidationProblem;
+use serde::Serialize;
 use std::convert::Infallible;
 use thiserror::Error;
 use warp::{http::StatusCode, reject::Reject, Rejection, Reply};
-use serde::Serialize;
-use crate::errors::error_codes::ERROR_CODES;
-use crate::errors::error_codes::ErrorCodes;
-use crate::models::error_response::ErrorResponse;
-use crate::models::error_response::ValidationProblem;
 
 #[derive(Error, Debug)]
 pub enum ApiError {
-  #[error("Message not found")]
-  NotFound,
-  #[error("Invalid input: {0}")]
-  BadRequest(String,u16),
-  #[error("Internal server error")]
-  InternalServerError,
-  #[error("custom")]
-  ErrorCode(ErrorCodes),
-  #[error("Multiple validation errors")]
-  MultipleErrors(Option<Vec<ErrorCodes>>, Option<String>, Option<String>)
+    #[error("Message not found")]
+    NotFound,
+    #[error("Invalid input: {0}")]
+    BadRequest(String, u16),
+    #[error("Internal server error")]
+    InternalServerError,
+    #[error("Unauthorized")]
+    Unauthorized,
+    #[error("custom")]
+    ErrorCode(ErrorCodes),
+    #[error("Multiple validation errors")]
+    MultipleErrors(Option<Vec<ErrorCodes>>, Option<String>, Option<String>),
 }
 
 impl Reject for ApiError {}
 
-
-
 pub async fn handle_rejection(err: Rejection) -> Result<impl Reply, Infallible> {
-  let dict = ERROR_CODES.read().unwrap();
-  let errors: ErrorResponse = if err.is_not_found() {
-    ErrorResponse { title: "Not Found".to_string(), status: StatusCode::NOT_FOUND.as_u16(), instance: None, details: None}
-  } else if let Some(e) = err.find::<ApiError>() {
-    match  e {
-      ApiError::NotFound => ErrorResponse { title: e.to_string(), status: StatusCode::NOT_FOUND.as_u16(), instance: None, details: None},
-      ApiError::BadRequest(details, code) => ErrorResponse { title: "Bad request".to_string(), status: StatusCode::BAD_REQUEST.as_u16(), instance: None, details: Some(vec![ValidationProblem {field: None, message: details.clone(), error_code: code.clone()}])},
-      ApiError::InternalServerError => ErrorResponse { title: "Internal server error".to_string(), status: StatusCode::INTERNAL_SERVER_ERROR.as_u16(), instance: None, details: Some(vec![ValidationProblem {field: None, message: e.to_string(), error_code: 0}])},
-      ApiError::ErrorCode(code) => {
-        if let Some(errorcode) = dict.get(code){
-          ErrorResponse { title: errorcode.message.clone(), status: errorcode.status_code.as_u16(), instance: None, details: Some(vec![ValidationProblem {field: None, message: errorcode.message.clone(), error_code: errorcode.code}])}//(errorcode.status_code, errorcode.code, errorcode.message.to_string())
-        } else {
-          ErrorResponse { title: "Internal server error".to_string(), status: StatusCode::INTERNAL_SERVER_ERROR.as_u16(), instance: None, details: Some(vec![ValidationProblem {field: None, message: e.to_string(), error_code: 0}])}
-        }  
-      },
-      ApiError::MultipleErrors(errors, field, instance) => {
-        let mut validation_problems: Option<Vec<ValidationProblem>> = Some(vec![]);
-        let mut status_code: u16 = 0;
-        if let Some(error_list) = errors {
-          for code in error_list {
-            if let Some(errorcode) = dict.get(code){
-              status_code = errorcode.status_code.as_u16();
-              if let Some(ref mut problems) = validation_problems {
-                problems.push(ValidationProblem {field: field.clone(), message: errorcode.message.clone(), error_code: errorcode.code});
-              }
-            } 
-          }
+    let dict = ERROR_CODES.read().unwrap();
+    let errors: ErrorResponse = if err.is_not_found() {
+        ErrorResponse {
+            title: "Not Found".to_string(),
+            status: StatusCode::NOT_FOUND.as_u16(),
+            instance: None,
+            details: None,
         }
-        ErrorResponse { title: e.to_string(), status: status_code, instance: instance.clone(), details: validation_problems}
-      }
+    } else if let Some(e) = err.find::<ApiError>() {
+        match e {
+            ApiError::NotFound => ErrorResponse {
+                title: e.to_string(),
+                status: StatusCode::NOT_FOUND.as_u16(),
+                instance: None,
+                details: None,
+            },
+            ApiError::BadRequest(details, code) => ErrorResponse {
+                title: "Bad request".to_string(),
+                status: StatusCode::BAD_REQUEST.as_u16(),
+                instance: None,
+                details: Some(vec![ValidationProblem {
+                    field: None,
+                    message: details.clone(),
+                    error_code: code.clone(),
+                }]),
+            },
+            ApiError::InternalServerError => ErrorResponse {
+                title: "Internal server error".to_string(),
+                status: StatusCode::INTERNAL_SERVER_ERROR.as_u16(),
+                instance: None,
+                details: Some(vec![ValidationProblem {
+                    field: None,
+                    message: e.to_string(),
+                    error_code: 0,
+                }]),
+            },
+            ApiError::Unauthorized => ErrorResponse {
+                title: e.to_string(),
+                status: StatusCode::UNAUTHORIZED.as_u16(),
+                instance: None,
+                details: None,
+            },
+            ApiError::ErrorCode(code) => {
+                if let Some(errorcode) = dict.get(code) {
+                    ErrorResponse {
+                        title: errorcode.message.clone(),
+                        status: errorcode.status_code.as_u16(),
+                        instance: None,
+                        details: Some(vec![ValidationProblem {
+                            field: None,
+                            message: errorcode.message.clone(),
+                            error_code: errorcode.code,
+                        }]),
+                    } //(errorcode.status_code, errorcode.code, errorcode.message.to_string())
+                } else {
+                    ErrorResponse {
+                        title: "Internal server error".to_string(),
+                        status: StatusCode::INTERNAL_SERVER_ERROR.as_u16(),
+                        instance: None,
+                        details: Some(vec![ValidationProblem {
+                            field: None,
+                            message: e.to_string(),
+                            error_code: 0,
+                        }]),
+                    }
+                }
+            }
+            ApiError::MultipleErrors(errors, field, instance) => {
+                let mut validation_problems: Option<Vec<ValidationProblem>> = Some(vec![]);
+                let mut status_code: u16 = 0;
+                if let Some(error_list) = errors {
+                    for code in error_list {
+                        if let Some(errorcode) = dict.get(code) {
+                            status_code = errorcode.status_code.as_u16();
+                            if let Some(ref mut problems) = validation_problems {
+                                problems.push(ValidationProblem {
+                                    field: field.clone(),
+                                    message: errorcode.message.clone(),
+                                    error_code: errorcode.code,
+                                });
+                            }
+                        }
+                    }
+                }
+                ErrorResponse {
+                    title: e.to_string(),
+                    status: status_code,
+                    instance: instance.clone(),
+                    details: validation_problems,
+                }
+            }
+        }
+    } else {
+        ErrorResponse {
+            title: "Internal server error".to_string(),
+            status: StatusCode::INTERNAL_SERVER_ERROR.as_u16(),
+            instance: None,
+            details: None,
+        }
+    };
+
+    let json = warp::reply::json(&errors);
+    let res_status_code: StatusCode;
+    match StatusCode::from_u16(errors.status) {
+        Ok(status_code) => res_status_code = status_code,
+        Err(_) => res_status_code = StatusCode::INTERNAL_SERVER_ERROR,
     }
-   } else {
-      ErrorResponse { title: "Internal server error".to_string(), status: StatusCode::INTERNAL_SERVER_ERROR.as_u16(), instance: None, details: None}       
-   };
 
-   let json = warp::reply::json(&errors);
-   let res_status_code: StatusCode;
-   match StatusCode::from_u16(errors.status) {
-    Ok(status_code)=> {res_status_code = status_code},
-    Err(_)=> {res_status_code = StatusCode::INTERNAL_SERVER_ERROR}
-   }
-
-   Ok(warp::reply::with_status(json, res_status_code))
+    Ok(warp::reply::with_status(json, res_status_code))
 }

--- a/src/models/auth_request.rs
+++ b/src/models/auth_request.rs
@@ -1,0 +1,9 @@
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+#[derive(Serialize, Deserialize, Debug, ToSchema)]
+#[serde(tag = "grant_type", rename_all = "snake_case")]
+pub enum AuthRequestDto {
+    User { username: String, password: String },
+    Client { client_id: String, client_secret: String },
+}

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,3 +1,4 @@
 pub mod error_response;
 pub mod messageModel;
 pub mod token_model;
+pub mod auth_request;

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,2 +1,3 @@
-pub mod messageModel;
 pub mod error_response;
+pub mod messageModel;
+pub mod token_model;

--- a/src/models/token_model.rs
+++ b/src/models/token_model.rs
@@ -1,0 +1,6 @@
+use serde::Serialize;
+
+#[derive(Debug, Serialize, utoipa::ToSchema, utoipa::ToResponse)]
+pub struct TokenResponseDto {
+    pub token: String,
+}

--- a/src/repositories/credentials_repository.rs
+++ b/src/repositories/credentials_repository.rs
@@ -1,0 +1,48 @@
+use async_trait::async_trait;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+#[async_trait]
+pub trait CredentialRepository: Send + Sync {
+    async fn validate_user(&self, username: &str, password: &str) -> bool;
+    async fn validate_client(&self, client_id: &str, client_secret: &str) -> bool;
+}
+
+pub struct InMemoryCredentialRepository {
+    users: Arc<Mutex<HashMap<String, String>>>,
+    clients: Arc<Mutex<HashMap<String, String>>>,
+}
+
+impl InMemoryCredentialRepository {
+    pub fn new() -> Self {
+        let mut users = HashMap::new();
+        users.insert("admin".to_string(), "password".to_string());
+        let mut clients = HashMap::new();
+        clients.insert("client".to_string(), "secret".to_string());
+        Self {
+            users: Arc::new(Mutex::new(users)),
+            clients: Arc::new(Mutex::new(clients)),
+        }
+    }
+}
+
+#[async_trait]
+impl CredentialRepository for InMemoryCredentialRepository {
+    async fn validate_user(&self, username: &str, password: &str) -> bool {
+        self.users
+            .lock()
+            .unwrap()
+            .get(username)
+            .map(|p| p == password)
+            .unwrap_or(false)
+    }
+
+    async fn validate_client(&self, client_id: &str, client_secret: &str) -> bool {
+        self.clients
+            .lock()
+            .unwrap()
+            .get(client_id)
+            .map(|s| s == client_secret)
+            .unwrap_or(false)
+    }
+}

--- a/src/repositories/mod.rs
+++ b/src/repositories/mod.rs
@@ -1,2 +1,3 @@
 pub mod base_Repository;
 pub mod token_repository;
+pub mod credentials_repository;

--- a/src/repositories/mod.rs
+++ b/src/repositories/mod.rs
@@ -1,1 +1,2 @@
 pub mod base_Repository;
+pub mod token_repository;

--- a/src/repositories/token_repository.rs
+++ b/src/repositories/token_repository.rs
@@ -1,0 +1,44 @@
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use std::sync::{Arc, Mutex};
+
+struct TokenEntry {
+    hashed: String,
+    expires_at: DateTime<Utc>,
+}
+
+#[async_trait]
+pub trait TokenRepository: Send + Sync {
+    async fn store_token(&self, hashed_token: String, expires_at: DateTime<Utc>);
+    async fn is_valid(&self, hashed_token: &str) -> bool;
+}
+
+pub struct InMemoryTokenRepository {
+    tokens: Arc<Mutex<Vec<TokenEntry>>>,
+}
+
+impl InMemoryTokenRepository {
+    pub fn new() -> Self {
+        Self {
+            tokens: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+}
+
+#[async_trait]
+impl TokenRepository for InMemoryTokenRepository {
+    async fn store_token(&self, hashed_token: String, expires_at: DateTime<Utc>) {
+        let mut tokens = self.tokens.lock().unwrap();
+        tokens.push(TokenEntry {
+            hashed: hashed_token,
+            expires_at,
+        });
+    }
+
+    async fn is_valid(&self, hashed_token: &str) -> bool {
+        let mut tokens = self.tokens.lock().unwrap();
+        let now = Utc::now();
+        tokens.retain(|t| t.expires_at > now);
+        tokens.iter().any(|t| t.hashed == hashed_token)
+    }
+}

--- a/src/server.rs
+++ b/src/server.rs
@@ -25,7 +25,7 @@ pub async fn run_server() -> (oneshot::Sender<()>, String) {
 
     let config = Arc::new(config::Config::from_env());
     let config_swagger = Arc::new(Config::from(format!("/{}/api-doc.json", config.api_base)));
-    let routes = controllers::base_routes(Arc::clone(&config));
+    let routes = controllers::routes(Arc::clone(&config));
     let static_files = warp::fs::dir(config.static_dir.clone());
 
     let port: u16 = config.port;

--- a/src/services/auth_service.rs
+++ b/src/services/auth_service.rs
@@ -1,0 +1,49 @@
+use async_trait::async_trait;
+use base64::{engine::general_purpose, Engine as _};
+use chrono::{Duration, Utc};
+use hex;
+use rand::RngCore;
+use sha2::{Digest, Sha256};
+
+use crate::models::token_model::TokenResponseDto;
+use crate::repositories::token_repository::TokenRepository;
+
+#[async_trait]
+pub trait AuthService: Send + Sync {
+    async fn generate_token(&self) -> TokenResponseDto;
+    async fn validate_token(&self, token: &str) -> bool;
+}
+
+pub struct AuthServiceImpl<R: TokenRepository> {
+    repository: R,
+    ttl_minutes: i64,
+}
+
+impl<R: TokenRepository> AuthServiceImpl<R> {
+    pub fn new(repository: R) -> Self {
+        Self {
+            repository,
+            ttl_minutes: 60,
+        }
+    }
+}
+
+#[async_trait]
+impl<R: TokenRepository + Send + Sync> AuthService for AuthServiceImpl<R> {
+    async fn generate_token(&self) -> TokenResponseDto {
+        let mut bytes = [0u8; 32];
+        rand::thread_rng().fill_bytes(&mut bytes);
+        let token = general_purpose::URL_SAFE_NO_PAD.encode(&bytes);
+        let hashed = Sha256::digest(token.as_bytes());
+        let hashed_hex = hex::encode(hashed);
+        let expires_at = Utc::now() + Duration::minutes(self.ttl_minutes);
+        self.repository.store_token(hashed_hex, expires_at).await;
+        TokenResponseDto { token }
+    }
+
+    async fn validate_token(&self, token: &str) -> bool {
+        let hashed = Sha256::digest(token.as_bytes());
+        let hashed_hex = hex::encode(hashed);
+        self.repository.is_valid(&hashed_hex).await
+    }
+}

--- a/src/services/auth_service.rs
+++ b/src/services/auth_service.rs
@@ -5,45 +5,75 @@ use hex;
 use rand::RngCore;
 use sha2::{Digest, Sha256};
 
-use crate::models::token_model::TokenResponseDto;
-use crate::repositories::token_repository::TokenRepository;
+use crate::errors::ApiError;
+use crate::models::{auth_request::AuthRequestDto, token_model::TokenResponseDto};
+use crate::repositories::{credentials_repository::CredentialRepository, token_repository::TokenRepository};
 
 #[async_trait]
 pub trait AuthService: Send + Sync {
-    async fn generate_token(&self) -> TokenResponseDto;
+    async fn generate_token(&self, request: AuthRequestDto) -> Result<TokenResponseDto, ApiError>;
     async fn validate_token(&self, token: &str) -> bool;
 }
 
-pub struct AuthServiceImpl<R: TokenRepository> {
-    repository: R,
+pub struct AuthServiceImpl<R: TokenRepository, C: CredentialRepository> {
+    token_repository: R,
+    credential_repository: C,
     ttl_minutes: i64,
 }
 
-impl<R: TokenRepository> AuthServiceImpl<R> {
-    pub fn new(repository: R) -> Self {
+impl<R: TokenRepository, C: CredentialRepository> AuthServiceImpl<R, C> {
+    pub fn new(token_repository: R, credential_repository: C) -> Self {
         Self {
-            repository,
+            token_repository,
+            credential_repository,
             ttl_minutes: 60,
         }
     }
 }
 
 #[async_trait]
-impl<R: TokenRepository + Send + Sync> AuthService for AuthServiceImpl<R> {
-    async fn generate_token(&self) -> TokenResponseDto {
+impl<R: TokenRepository + Send + Sync, C: CredentialRepository + Send + Sync> AuthService
+    for AuthServiceImpl<R, C>
+{
+    async fn generate_token(
+        &self,
+        request: AuthRequestDto,
+    ) -> Result<TokenResponseDto, ApiError> {
+        let valid = match request {
+            AuthRequestDto::User { username, password } => {
+                self.credential_repository
+                    .validate_user(&username, &password)
+                    .await
+            }
+            AuthRequestDto::Client {
+                client_id,
+                client_secret,
+            } => {
+                self.credential_repository
+                    .validate_client(&client_id, &client_secret)
+                    .await
+            }
+        };
+
+        if !valid {
+            return Err(ApiError::Unauthorized);
+        }
+
         let mut bytes = [0u8; 32];
         rand::thread_rng().fill_bytes(&mut bytes);
         let token = general_purpose::URL_SAFE_NO_PAD.encode(&bytes);
         let hashed = Sha256::digest(token.as_bytes());
         let hashed_hex = hex::encode(hashed);
         let expires_at = Utc::now() + Duration::minutes(self.ttl_minutes);
-        self.repository.store_token(hashed_hex, expires_at).await;
-        TokenResponseDto { token }
+        self.token_repository
+            .store_token(hashed_hex, expires_at)
+            .await;
+        Ok(TokenResponseDto { token })
     }
 
     async fn validate_token(&self, token: &str) -> bool {
         let hashed = Sha256::digest(token.as_bytes());
         let hashed_hex = hex::encode(hashed);
-        self.repository.is_valid(&hashed_hex).await
+        self.token_repository.is_valid(&hashed_hex).await
     }
 }

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -1,1 +1,2 @@
+pub mod auth_service;
 pub mod base_service;

--- a/src/swagger.rs
+++ b/src/swagger.rs
@@ -26,7 +26,7 @@ use warp::{
         crate::controllers::base_controller::handle_create_message,
         crate::controllers::base_controller::handle_search_messages,
         crate::controllers::auth_controller::generate_token,
-        crate::controllers::auth_controller::protected_endpoint,
+        crate::controllers::protected_controller::protected_endpoint,
     ),
     info(
         title = "Rust Base Backend API ",

--- a/src/swagger.rs
+++ b/src/swagger.rs
@@ -1,6 +1,6 @@
 use crate::models::error_response::{ErrorResponse, ValidationProblem};
 use crate::models::messageModel::{CreateMessageModelDto, MessageResponseDto};
-use crate::models::token_model::TokenResponseDto;
+use crate::models::{auth_request::AuthRequestDto, token_model::TokenResponseDto};
 use utoipa::{
     openapi::{
         self,
@@ -37,6 +37,7 @@ use warp::{
         schemas(
             CreateMessageModelDto,
             MessageResponseDto,
+            AuthRequestDto,
             TokenResponseDto,
             ErrorResponse,
             ValidationProblem

--- a/src/swagger.rs
+++ b/src/swagger.rs
@@ -1,22 +1,33 @@
-use utoipa::OpenApi;
-use crate::models::messageModel::{CreateMessageModelDto, MessageResponseDto};
 use crate::models::error_response::{ErrorResponse, ValidationProblem};
-use utoipauto::utoipauto;
-
-use warp::{
-    http::Uri,
-    hyper::{Response, StatusCode},
-    path::{FullPath, Tail}, Rejection, Reply,
+use crate::models::messageModel::{CreateMessageModelDto, MessageResponseDto};
+use crate::models::token_model::TokenResponseDto;
+use utoipa::{
+    openapi::{
+        self,
+        security::{ApiKey, ApiKeyValue, SecurityScheme},
+    },
+    Modify, OpenApi,
 };
+
 use std::str::FromStr;
 use std::sync::Arc;
 use utoipa_swagger_ui::Config;
+use warp::{
+    http::Uri,
+    hyper::{Response, StatusCode},
+    path::{FullPath, Tail},
+    Rejection, Reply,
+};
 
-#[utoipauto(
-    paths = "./src/controllers"
-)]
 #[derive(OpenApi)]
 #[openapi(
+    paths(
+        crate::controllers::base_controller::handle_get_messages,
+        crate::controllers::base_controller::handle_create_message,
+        crate::controllers::base_controller::handle_search_messages,
+        crate::controllers::auth_controller::generate_token,
+        crate::controllers::auth_controller::protected_endpoint,
+    ),
     info(
         title = "Rust Base Backend API ",
         version = "1.0.0",
@@ -26,13 +37,26 @@ use utoipa_swagger_ui::Config;
         schemas(
             CreateMessageModelDto,
             MessageResponseDto,
+            TokenResponseDto,
             ErrorResponse,
             ValidationProblem
         )
-    )
+    ),
+    modifiers(&SecurityAddon)
 )]
 pub struct ApiDoc;
 
+struct SecurityAddon;
+
+impl Modify for SecurityAddon {
+    fn modify(&self, openapi: &mut openapi::OpenApi) {
+        let components = openapi.components.get_or_insert_with(Default::default);
+        components.add_security_scheme(
+            "api_key",
+            SecurityScheme::ApiKey(ApiKey::Header(ApiKeyValue::new("Authorization"))),
+        );
+    }
+}
 
 pub async fn serve_swagger(
     full_path: FullPath,
@@ -42,9 +66,9 @@ pub async fn serve_swagger(
     let api_base_path = std::env::var("API_BASE").expect("API_BASE must be set");
 
     if full_path.as_str() == format!("/{}/swagger-ui", api_base_path) {
-        return Ok(Box::new(warp::redirect::found(Uri::from_str(
-            format!("/{}/swagger-ui", api_base_path.clone()).as_str()
-        ).unwrap())));
+        return Ok(Box::new(warp::redirect::found(
+            Uri::from_str(format!("/{}/swagger-ui", api_base_path.clone()).as_str()).unwrap(),
+        )));
     }
 
     let path = tail.as_str();

--- a/src/test/auth_controller_test.rs
+++ b/src/test/auth_controller_test.rs
@@ -1,0 +1,23 @@
+use std::sync::Arc;
+use warp::Reply;
+
+use crate::controllers::auth_controller::{generate_token, protected_endpoint};
+use crate::repositories::token_repository::InMemoryTokenRepository;
+use crate::services::auth_service::{AuthService, AuthServiceImpl};
+
+#[tokio::test]
+async fn handler_generate_token() {
+    let repo = InMemoryTokenRepository::new();
+    let service = AuthServiceImpl::new(repo);
+    let reply = generate_token(Arc::new(service))
+        .await
+        .unwrap()
+        .into_response();
+    assert_eq!(reply.status(), 200);
+}
+
+#[tokio::test]
+async fn handler_protected_endpoint() {
+    let reply = protected_endpoint().await.unwrap().into_response();
+    assert_eq!(reply.status(), 200);
+}

--- a/src/test/auth_controller_test.rs
+++ b/src/test/auth_controller_test.rs
@@ -2,18 +2,40 @@ use std::sync::Arc;
 use warp::Reply;
 
 use crate::controllers::auth_controller::{generate_token, protected_endpoint};
-use crate::repositories::token_repository::InMemoryTokenRepository;
+use crate::models::auth_request::AuthRequestDto;
+use crate::repositories::{
+    credentials_repository::InMemoryCredentialRepository,
+    token_repository::InMemoryTokenRepository,
+};
 use crate::services::auth_service::{AuthService, AuthServiceImpl};
 
 #[tokio::test]
 async fn handler_generate_token() {
-    let repo = InMemoryTokenRepository::new();
-    let service = AuthServiceImpl::new(repo);
-    let reply = generate_token(Arc::new(service))
+    let token_repo = InMemoryTokenRepository::new();
+    let cred_repo = InMemoryCredentialRepository::new();
+    let service = AuthServiceImpl::new(token_repo, cred_repo);
+    let request = AuthRequestDto::Client {
+        client_id: "client".to_string(),
+        client_secret: "secret".to_string(),
+    };
+    let reply = generate_token(Arc::new(service), request)
         .await
         .unwrap()
         .into_response();
     assert_eq!(reply.status(), 200);
+}
+
+#[tokio::test]
+async fn handler_generate_token_invalid_credentials() {
+    let token_repo = InMemoryTokenRepository::new();
+    let cred_repo = InMemoryCredentialRepository::new();
+    let service = AuthServiceImpl::new(token_repo, cred_repo);
+    let request = AuthRequestDto::Client {
+        client_id: "client".to_string(),
+        client_secret: "wrong".to_string(),
+    };
+    let result = generate_token(Arc::new(service), request).await;
+    assert!(result.is_err());
 }
 
 #[tokio::test]

--- a/src/test/auth_controller_test.rs
+++ b/src/test/auth_controller_test.rs
@@ -1,11 +1,10 @@
 use std::sync::Arc;
 use warp::Reply;
 
-use crate::controllers::auth_controller::{generate_token, protected_endpoint};
+use crate::controllers::auth_controller::generate_token;
 use crate::models::auth_request::AuthRequestDto;
 use crate::repositories::{
-    credentials_repository::InMemoryCredentialRepository,
-    token_repository::InMemoryTokenRepository,
+    credentials_repository::InMemoryCredentialRepository, token_repository::InMemoryTokenRepository,
 };
 use crate::services::auth_service::{AuthService, AuthServiceImpl};
 
@@ -36,10 +35,4 @@ async fn handler_generate_token_invalid_credentials() {
     };
     let result = generate_token(Arc::new(service), request).await;
     assert!(result.is_err());
-}
-
-#[tokio::test]
-async fn handler_protected_endpoint() {
-    let reply = protected_endpoint().await.unwrap().into_response();
-    assert_eq!(reply.status(), 200);
 }

--- a/src/test/auth_repository_tests.rs
+++ b/src/test/auth_repository_tests.rs
@@ -1,3 +1,6 @@
+use crate::repositories::credentials_repository::{
+    CredentialRepository, InMemoryCredentialRepository,
+};
 use crate::repositories::token_repository::{InMemoryTokenRepository, TokenRepository};
 use chrono::{Duration, Utc};
 use hex;
@@ -12,4 +15,13 @@ async fn store_and_validate_token() {
     repo.store_token(hashed_hex.clone(), Utc::now() + Duration::minutes(5))
         .await;
     assert!(repo.is_valid(&hashed_hex).await);
+}
+
+#[tokio::test]
+async fn validate_user_and_client_credentials() {
+    let repo = InMemoryCredentialRepository::new();
+    assert!(repo.validate_user("admin", "password").await);
+    assert!(!repo.validate_user("admin", "wrong").await);
+    assert!(repo.validate_client("client", "secret").await);
+    assert!(!repo.validate_client("client", "nope").await);
 }

--- a/src/test/auth_repository_tests.rs
+++ b/src/test/auth_repository_tests.rs
@@ -1,0 +1,15 @@
+use crate::repositories::token_repository::{InMemoryTokenRepository, TokenRepository};
+use chrono::{Duration, Utc};
+use hex;
+use sha2::{Digest, Sha256};
+
+#[tokio::test]
+async fn store_and_validate_token() {
+    let repo = InMemoryTokenRepository::new();
+    let token = "test";
+    let hashed = Sha256::digest(token.as_bytes());
+    let hashed_hex = hex::encode(hashed);
+    repo.store_token(hashed_hex.clone(), Utc::now() + Duration::minutes(5))
+        .await;
+    assert!(repo.is_valid(&hashed_hex).await);
+}

--- a/src/test/auth_service_test.rs
+++ b/src/test/auth_service_test.rs
@@ -1,0 +1,10 @@
+use crate::repositories::token_repository::InMemoryTokenRepository;
+use crate::services::auth_service::{AuthService, AuthServiceImpl};
+
+#[tokio::test]
+async fn generate_and_validate_token() {
+    let repo = InMemoryTokenRepository::new();
+    let service = AuthServiceImpl::new(repo);
+    let token = service.generate_token().await.token;
+    assert!(service.validate_token(&token).await);
+}

--- a/src/test/auth_service_test.rs
+++ b/src/test/auth_service_test.rs
@@ -1,10 +1,29 @@
+use crate::models::auth_request::AuthRequestDto;
+use crate::repositories::credentials_repository::InMemoryCredentialRepository;
 use crate::repositories::token_repository::InMemoryTokenRepository;
 use crate::services::auth_service::{AuthService, AuthServiceImpl};
 
 #[tokio::test]
 async fn generate_and_validate_token() {
-    let repo = InMemoryTokenRepository::new();
-    let service = AuthServiceImpl::new(repo);
-    let token = service.generate_token().await.token;
+    let token_repo = InMemoryTokenRepository::new();
+    let cred_repo = InMemoryCredentialRepository::new();
+    let service = AuthServiceImpl::new(token_repo, cred_repo);
+    let request = AuthRequestDto::User {
+        username: "admin".to_string(),
+        password: "password".to_string(),
+    };
+    let token = service.generate_token(request).await.unwrap().token;
     assert!(service.validate_token(&token).await);
+}
+
+#[tokio::test]
+async fn reject_invalid_credentials() {
+    let token_repo = InMemoryTokenRepository::new();
+    let cred_repo = InMemoryCredentialRepository::new();
+    let service = AuthServiceImpl::new(token_repo, cred_repo);
+    let request = AuthRequestDto::User {
+        username: "admin".to_string(),
+        password: "wrong".to_string(),
+    };
+    assert!(service.generate_token(request).await.is_err());
 }

--- a/src/test/integration_test.rs
+++ b/src/test/integration_test.rs
@@ -185,7 +185,16 @@ async fn test_auth_token_and_protected() {
     let client = reqwest::Client::new();
 
     let token_addr = build_address(&base, "auth/token");
-    let token_resp = client.post(token_addr).send().await.unwrap();
+    let token_resp = client
+        .post(token_addr)
+        .json(&serde_json::json!({
+            "grant_type": "user",
+            "username": "admin",
+            "password": "password"
+        }))
+        .send()
+        .await
+        .unwrap();
     assert_eq!(token_resp.status(), 200);
     let body: Value = token_resp.json().await.unwrap();
     let token = body["token"].as_str().unwrap();

--- a/src/test/integration_test.rs
+++ b/src/test/integration_test.rs
@@ -178,3 +178,29 @@ async fn test_static_file_serving() {
 
     let _ = shutdown.send(());
 }
+
+#[tokio::test]
+async fn test_auth_token_and_protected() {
+    let (shutdown, base) = spawn_server().await;
+    let client = reqwest::Client::new();
+
+    let token_addr = build_address(&base, "auth/token");
+    let token_resp = client.post(token_addr).send().await.unwrap();
+    assert_eq!(token_resp.status(), 200);
+    let body: Value = token_resp.json().await.unwrap();
+    let token = body["token"].as_str().unwrap();
+
+    let protected_addr = build_address(&base, "protected");
+    let unauth = client.get(protected_addr.clone()).send().await.unwrap();
+    assert_eq!(unauth.status(), 401);
+
+    let auth = client
+        .get(protected_addr)
+        .header("Authorization", format!("Bearer {}", token))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(auth.status(), 200);
+
+    let _ = shutdown.send(());
+}

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -3,3 +3,6 @@ pub mod base_service_test;
 pub mod base_controller_test;
 pub mod integration_test;
 pub mod static_files_test;
+pub mod auth_repository_tests;
+pub mod auth_service_test;
+pub mod auth_controller_test;

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -6,3 +6,4 @@ pub mod static_files_test;
 pub mod auth_repository_tests;
 pub mod auth_service_test;
 pub mod auth_controller_test;
+pub mod protected_controller_test;

--- a/src/test/protected_controller_test.rs
+++ b/src/test/protected_controller_test.rs
@@ -1,0 +1,9 @@
+use warp::Reply;
+
+use crate::controllers::protected_controller::protected_endpoint;
+
+#[tokio::test]
+async fn handler_protected_endpoint() {
+    let reply = protected_endpoint().await.unwrap().into_response();
+    assert_eq!(reply.status(), 200);
+}


### PR DESCRIPTION
## Summary
- add token generation and protected endpoints using secure random tokens
- document how to obtain and use the token via Swagger
- cover repository, service and controller layers with tests

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68a938d755d48320a5ccab7b6fa69d25