### PR TITLE
chore: update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,26 +4,26 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-tokio = { version = "1.38.1", features = ["full"] }
-serde = { version = "1.0.204", features = ["derive"] }
-serde_json = "1.0.120"
-thiserror = "1.0"
-async-trait = "0.1.50"
-warp = "0.3"
-lazy_static = "1.4"
-dotenv = "0.15"
-utoipa = "4"
-utoipa-swagger-ui = "7"
-utoipauto = "0.1.12"
-mockall = "0.13"
-once_cell = "1.8"
-rand = "0.8"
-sha2 = "0.10"
-base64 = "0.21"
-hex = "0.4"
-chrono = { version = "0.4", features = ["serde", "clock"] }
+tokio = { version = "1.47.1", features = ["full"] }
+serde = { version = "1.0.219", features = ["derive"] }
+serde_json = "1.0.143"
+thiserror = "2.0.16"
+async-trait = "0.1.89"
+warp = { version = "0.4.2", features = ["server", "test"] }
+lazy_static = "1.5.0"
+dotenv = "0.15.0"
+utoipa = "5.4.0"
+utoipa-swagger-ui = "9.0.2"
+utoipauto = "0.2.0"
+mockall = "0.13.1"
+once_cell = "1.21.3"
+rand = "0.9.2"
+sha2 = "0.10.9"
+base64 = "0.22.1"
+hex = "0.4.3"
+chrono = { version = "0.4.41", features = ["serde", "clock"] }
 
 [dev-dependencies]
-reqwest = { version = "0.12", features = ["json"] }
-tokio = { version = "1.38.1", features = ["full", "test-util"] }
-once_cell = "1.8"
+reqwest = { version = "0.12.23", features = ["json"] }
+tokio = { version = "1.47.1", features = ["full", "test-util"] }
+once_cell = "1.21.3"

--- a/src/services/auth_service.rs
+++ b/src/services/auth_service.rs
@@ -60,7 +60,7 @@ impl<R: TokenRepository + Send + Sync, C: CredentialRepository + Send + Sync> Au
         }
 
         let mut bytes = [0u8; 32];
-        rand::thread_rng().fill_bytes(&mut bytes);
+        rand::rng().fill_bytes(&mut bytes);
         let token = general_purpose::URL_SAFE_NO_PAD.encode(&bytes);
         let hashed = Sha256::digest(token.as_bytes());
         let hashed_hex = hex::encode(hashed);

--- a/src/swagger.rs
+++ b/src/swagger.rs
@@ -79,7 +79,7 @@ pub async fn serve_swagger(
                 Ok(Box::new(
                     Response::builder()
                         .header("Content-Type", file.content_type)
-                        .body(file.bytes),
+                        .body(file.bytes.into_owned()),
                 ))
             } else {
                 Ok(Box::new(StatusCode::NOT_FOUND))


### PR DESCRIPTION
## Summary
- update Cargo dependencies to latest releases
- adapt server setup for warp 0.4 API
- update swagger handler and random token generation for new APIs

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68abde2d221883209236f56115f3c9cb